### PR TITLE
Hotfix chart display

### DIFF
--- a/src/vn/edu/rmit/kuri/output/Display.java
+++ b/src/vn/edu/rmit/kuri/output/Display.java
@@ -175,9 +175,9 @@ public class Display {
       // the distance must be rounded due to the limit of the program (only represent * with integer position)
       // the reason for -2: -1 for the double array start from 0 rather than 1, -1 for the 1st col and the last row is used for axes
       int position = vertical - 2;  // last row in the display area
-      if (zeroCount != valueForDisplay.size()) {
-        position = Math.round((vertical - 2) - (((float) value / max) * (vertical - 2)));
-      }
+//      if (zeroCount != valueForDisplay.size()) {
+      position = Math.round((vertical - 2) - (((float) value / max) * (vertical - 2)));
+//    }
       valuePositionOnChart.add(position);
     }
 

--- a/src/vn/edu/rmit/kuri/output/Display.java
+++ b/src/vn/edu/rmit/kuri/output/Display.java
@@ -165,7 +165,9 @@ public class Display {
       if (max < i) {
         max = i;
       }
+      if (i == 0) {
       zeroCount += 1;
+      }
     }
 
     // store position values in an ArrayList
@@ -175,9 +177,9 @@ public class Display {
       // the distance must be rounded due to the limit of the program (only represent * with integer position)
       // the reason for -2: -1 for the double array start from 0 rather than 1, -1 for the 1st col and the last row is used for axes
       int position = vertical - 2;  // last row in the display area
-//      if (zeroCount != valueForDisplay.size()) {
+      if (zeroCount != valueForDisplay.size()) {
       position = Math.round((vertical - 2) - (((float) value / max) * (vertical - 2)));
-//    }
+      }
       valuePositionOnChart.add(position);
     }
 

--- a/src/vn/edu/rmit/kuri/output/Display.java
+++ b/src/vn/edu/rmit/kuri/output/Display.java
@@ -154,7 +154,7 @@ public class Display {
       System.out.println("Cannot draw chart with more than 79 groups.");
       return;
     }
-    //add hotfix branch. Begin debugging
+    //add hotfix branch to fix chart display
 
     // find the max value to calculate the position of the * based on it
     // each * present a value from a group

--- a/src/vn/edu/rmit/kuri/output/Display.java
+++ b/src/vn/edu/rmit/kuri/output/Display.java
@@ -154,6 +154,7 @@ public class Display {
       System.out.println("Cannot draw chart with more than 79 groups.");
       return;
     }
+    //add hotfix branch. Begin debugging
 
     // find the max value to calculate the position of the * based on it
     // each * present a value from a group


### PR DESCRIPTION
hotfix resolved: remove if statement: zeroCount!= ValueForDisplay
chart cannot be drawn correctly because zeroCount is looped to be equal to valueForDisplay (164-169) and then the condition to draw chart hinges on zerCount not being equal to ValueForDisplay